### PR TITLE
Bug fix: define LONG_IS_64BITS automatically for e.g. x86-64

### DIFF
--- a/watcom/h/watcom.h
+++ b/watcom/h/watcom.h
@@ -38,6 +38,12 @@
 #include "clibext.h"
 #endif
 
+#ifndef LONG_IS_64BITS
+  #ifdef __LP64__
+    #define LONG_IS_64BITS
+  #endif
+#endif
+
 #if !defined(__sun__) && !defined(sun) && !defined(__sgi) && !defined(__hppa) && !defined(_AIX) && !defined(__alpha) && !defined(_TYPES_H_) && !defined(_SYS_TYPES_H)
     typedef unsigned        uint;
 #endif


### PR DESCRIPTION
`watcom/h/watcom.h` uses a macro `LONG_IS_64BITS` to decide how to define the types `uint_32`, `unsigned_32`, etc.  However, `LONG_IS_64BITS` is never defined anywhere.  This leads to bogus output, for example in `Write_Stub_File( )`, on x86-64.

The definition for `LONG_IS_64BITS` which I am proposing is from OW v2 (https://github.com/open-watcom/open-watcom-v2).